### PR TITLE
Removed rule to enforce space inside hash literal

### DIFF
--- a/config/style_guides/ruby.yml
+++ b/config/style_guides/ruby.yml
@@ -411,7 +411,7 @@ Style/SpaceInsideBlockBraces:
 Style/SpaceInsideHashLiteralBraces:
   Description: Use spaces inside hash literal braces - or don't.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
-  Enabled: true
+  Enabled: false
   EnforcedStyle: space
   EnforcedStyleForEmptyBraces: no_space
   SupportedStyles:


### PR DESCRIPTION
I think this is best seen in let blocks in RSpec.

Relates to un-changed comments on
https://github.com/q-centrix/readmissions-api/pull/7