### PR TITLE
Rename outdated cop

### DIFF
--- a/config/style_guides/ruby.yml
+++ b/config/style_guides/ruby.yml
@@ -48,7 +48,7 @@ Layout/HashAlignment:
   - always_ignore
   - ignore_implicit
   - ignore_explicit
-Layout/ParametersAlignment:
+Layout/ParameterAlignment:
   Description: Align the parameters of a method call if they span more than one line.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-double-indent
   Enabled: true


### PR DESCRIPTION
it wasn't working and now it's working

https://rubocop.readthedocs.io/en/latest/cops_layout/#layoutparameteralignment

![cop](https://user-images.githubusercontent.com/17052671/73692272-da49fd00-4688-11ea-86e3-733a60d1a17e.png)
