### PR TITLE
RIMPL-257 Change hash alignment rule from 'key' to 'table'

### DIFF
--- a/config/style_guides/ruby.yml
+++ b/config/style_guides/ruby.yml
@@ -40,7 +40,7 @@ Layout/AccessModifierIndentation:
 Layout/HashAlignment:
   Description: Align the elements of a hash literal if they span more than one line.
   Enabled: true
-  EnforcedHashRocketStyle: key
+  EnforcedHashRocketStyle: table
   EnforcedColonStyle: key
   EnforcedLastArgumentHashStyle: always_inspect
   SupportedLastArgumentHashStyles:


### PR DESCRIPTION
We're getting constant 'hash alignment'  issues from code climate. From my understanding, these are not in agreement with our actual style. example:
![Screen Shot 2020-04-15 at 2 28 22 PM](https://user-images.githubusercontent.com/23107466/79391016-97789100-7f25-11ea-877e-140bf8205c86.png)
With the current rule, fixing the code climate errors would mean having one single space between each key and hash rocket. I believe our agreed upon standard is to align all hash rockets instead, for a cleaner, table style look:
![Screen Shot 2020-04-15 at 2 32 36 PM](https://user-images.githubusercontent.com/23107466/79391203-f8a06480-7f25-11ea-8fca-02dadd9bab96.png)

This updates the rule to allow hash alignment in line (ha) with our company standards.