### PR TITLE
Revert "RIMPL-257 Change hash alignment rule from 'key' to 'table'"

### DIFF
--- a/config/style_guides/ruby.yml
+++ b/config/style_guides/ruby.yml
@@ -40,7 +40,7 @@ Layout/AccessModifierIndentation:
 Layout/HashAlignment:
   Description: Align the elements of a hash literal if they span more than one line.
   Enabled: true
-  EnforcedHashRocketStyle: table
+  EnforcedHashRocketStyle: key
   EnforcedColonStyle: key
   EnforcedLastArgumentHashStyle: always_inspect
   SupportedLastArgumentHashStyles:


### PR DESCRIPTION
Reverts q-centrix/hound#26