### PR TITLE
Allow both key and separate in HashAlignment

### DIFF
--- a/config/style_guides/ruby.yml
+++ b/config/style_guides/ruby.yml
@@ -40,8 +40,12 @@ Layout/AccessModifierIndentation:
 Layout/HashAlignment:
   Description: Align the elements of a hash literal if they span more than one line.
   Enabled: true
-  EnforcedHashRocketStyle: key
-  EnforcedColonStyle: key
+  EnforcedHashRocketStyle:
+  - key
+  - table
+  EnforcedColonStyle:
+  - key
+  - table
   EnforcedLastArgumentHashStyle: always_inspect
   SupportedLastArgumentHashStyles:
   - always_inspect


### PR DESCRIPTION
Rubocop errors when table is not allowed
![Screen Shot 2020-11-17 at 2 28 05 PM](https://user-images.githubusercontent.com/20118615/99458722-d61e6180-28e1-11eb-99ca-f94fd2452a62.png)

No errors when table is allowed
![Screen Shot 2020-11-17 at 2 28 37 PM](https://user-images.githubusercontent.com/20118615/99458753-e46c7d80-28e1-11eb-89d8-eec92eaa49da.png)

Rubocop errors when key is not allowed
![Screen Shot 2020-11-17 at 2 30 03 PM](https://user-images.githubusercontent.com/20118615/99458773-ed5d4f00-28e1-11eb-9a5f-956e5cc66be9.png)

No errors when key is allowed
![Screen Shot 2020-11-17 at 2 30 37 PM](https://user-images.githubusercontent.com/20118615/99458798-f77f4d80-28e1-11eb-9419-6d3a7376abb6.png)

