### PR TITLE
fix deprecated cop

### DIFF
--- a/config/style_guides/ruby.yml
+++ b/config/style_guides/ruby.yml
@@ -1039,7 +1039,8 @@ Lint/UselessAssignment:
   Description: Checks for useless assignment to a local variable.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#underscore-unused-vars
   Enabled: true
-Lint/UselessComparison:
+#Lint/UselessComparison:
+Lint/BinaryOperatorWithIdenticalOperands:
   Description: Checks for comparison of something with itself.
   Enabled: true
 Lint/UselessElseWithoutRescue:


### PR DESCRIPTION
Running local rubocop throws errors on web asking to 
```
# This no longer supported
 Lint/UselessComparison
# use this instead
Lint/BinaryOperatorWithIdenticalOperands
```